### PR TITLE
Fix: Allow await in REPL by wrapping eval code in async IIFE

### DIFF
--- a/repl.ts
+++ b/repl.ts
@@ -318,8 +318,11 @@ export async function evaluateCode(code: string): Promise<void> {
   }
 
   try {
-    const finalCode = `"use strict";\n${importPrefix}${code}`;
-    const result = await (async function() { return eval(finalCode); }).call(globalThis);
+    const userCodeWithImports = `${importPrefix}${code}`;
+    const codeToEval = `(async () => { "use strict";
+${userCodeWithImports}
+})();`;
+    const result = await (async function() { return eval(codeToEval); }).call(globalThis);
     if (result !== undefined) {
       console.log(Deno.inspect(result, { colors: true, depth: 4, strAbbreviateSize: 500 }));
     }


### PR DESCRIPTION
The REPL's `evaluateCode` function was previously evaluating your code directly within an `async` function context. However, this did not allow the use of `await` at the top level of the code you provided, leading to a SyntaxError.

This change modifies `evaluateCode` to wrap your code (along with any automatic import prefixes) within an async Immediately Invoked Function Expression (IIFE) string before passing it to `eval`.

This ensures that `await` can be used as you expected in the REPL, as the code is now executed within a proper async function scope.